### PR TITLE
refactor: update middleware dependencies

### DIFF
--- a/Classes/ErrorFormatter/JsonApiFormatter.php
+++ b/Classes/ErrorFormatter/JsonApiFormatter.php
@@ -11,7 +11,7 @@ class JsonApiFormatter extends AbstractFormatter
 {
     protected $contentTypes = ['application/json', 'application/vnd.api+json'];
 
-    protected function format(Throwable $error): string
+    protected function format(Throwable $error, string $contentType): string
     {
         return (string) \json_encode($this->serializeError($error));
     }

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "league/tactician": "^2.0-rc1",
         "nikic/fast-route": "^1.3.0",
         "nikolaposa/cascader": "^1.2.0",
-        "middlewares/error-handler": "^2.0.0",
-        "middlewares/payload": "^2.1.1",
+        "middlewares/error-handler": "^v3.0.1",
+        "middlewares/payload": "^v3.0.1",
         "dfau/toujou-oauth2-server": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
We need to update the dependency to be compatible with https://github.com/DFAU/toujou-oauth2-server/pull/4.

As a method signature has changed for the JsonApiFormatter we should check where we use this class.