### PR TITLE
refactor: set php platform version to 7.3 to prevent fractal setCurre…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
         }
     },
     "config": {
+        "platform": {
+            "php": "7.3.27"
+        },
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",
         "allow-plugins": {


### PR DESCRIPTION
…ntScope signature errors

PHP Fatal error:  Declaration of League\Fractal\TransformerAbstract::setCurrentScope(League\Fractal\Scope $currentScope): League\Fractal\TransformerAbstract must be compatible with DFAU\ToujouApi\Transformer\ResourceTransformerInterface::setCurrentScope($currentScope) in /home/runner/work/toujou-api/toujou-api/Classes/Domain/Transformer/FileTransformer.php on line 215