### PR TITLE
fix: adapt TSFE init, remove obsolete method call

### DIFF
--- a/Classes/CommandBus/MapByConfiguration.php
+++ b/Classes/CommandBus/MapByConfiguration.php
@@ -48,8 +48,11 @@ class MapByConfiguration implements CommandToHandlerMapping
 
     public function findHandlerForCommand(string $commandFQCN): MethodToCall
     {
-        // TODO: Implement findHandlerForCommand() method.
+        $this->loadConfiguration();
+        if (!\array_key_exists($commandFQCN, $this->commandHandlerMap)) {
+            throw FailedToMapCommand::className($commandFQCN);
+        }
 
-        // v11change TODO : also fix "get" methods
+        return new MethodToCall($this->commandHandlerMap[$commandFQCN][0], $this->commandHandlerMap[$commandFQCN][1]);
     }
 }

--- a/Classes/Domain/CommandHandler/ConvergenceCommandHandler.php
+++ b/Classes/Domain/CommandHandler/ConvergenceCommandHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DFAU\ToujouApi\Domain\CommandHandler;
 
-use League\Tactician\CommandBus;
 use Cascader\Cascader;
 use DFAU\Convergence\Operations\AbstractResourceOperation;
 use DFAU\Convergence\Operations\AddResource;
@@ -18,6 +17,7 @@ use DFAU\ToujouApi\Domain\Command\ReplaceTcaResourceCommand;
 use DFAU\ToujouApi\Domain\Command\UnitOfWorkTcaResourceCommand;
 use DFAU\ToujouApi\Resource\Operation;
 use DFAU\ToujouApi\Resource\ResourceOperationToCommandMap;
+use League\Tactician\CommandBus;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ConvergenceCommandHandler

--- a/Classes/Domain/Repository/AbstractDatabaseResourceRepository.php
+++ b/Classes/Domain/Repository/AbstractDatabaseResourceRepository.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace DFAU\ToujouApi\Domain\Repository;
 
-use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use DFAU\ToujouApi\Database\Query\Restriction\ApiRestrictionContainer;
 use DFAU\ToujouApi\Domain\Value\ZuluDate;
 use League\Fractal\Pagination\Cursor;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 abstract class AbstractDatabaseResourceRepository implements ApiResourceRepository, DatabaseResourceRepository, PageRelationRepository

--- a/Classes/Middleware/ApiEntrypoint.php
+++ b/Classes/Middleware/ApiEntrypoint.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace DFAU\ToujouApi\Middleware;
 
-use Middlewares\ErrorFormatter\XmlFormatter;
-use Middlewares\ErrorFormatter\PlainFormatter;
 use DFAU\ToujouApi\ErrorFormatter\JsonApiFormatter;
 use DFAU\ToujouApi\Http\RequestHandler;
-use Middlewares\ErrorFormatter;
+use Middlewares\ErrorFormatter\PlainFormatter;
+use Middlewares\ErrorFormatter\XmlFormatter;
 use Middlewares\ErrorHandler;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -17,7 +16,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Http\MiddlewareDispatcher;
 use TYPO3\CMS\Core\Http\MiddlewareStackResolver;
 use TYPO3\CMS\Core\Site\Entity\Site;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ApiEntrypoint implements MiddlewareInterface
 {

--- a/Classes/Middleware/ApiEntrypoint.php
+++ b/Classes/Middleware/ApiEntrypoint.php
@@ -62,10 +62,10 @@ class ApiEntrypoint implements MiddlewareInterface
         $middlewares = $this->middlewareStackResolver->resolve('toujou_api');
 
         $errorHandler = new ErrorHandler([
+            new PlainFormatter(),
             new JsonApiFormatter(),
             new XmlFormatter(),
         ]);
-        $errorHandler->defaultFormatter(new PlainFormatter());
 
         $middlewares[] = $errorHandler;
 

--- a/Classes/Middleware/CheckBeUserAuthorization.php
+++ b/Classes/Middleware/CheckBeUserAuthorization.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace DFAU\ToujouApi\Middleware;
 
-use TYPO3\CMS\Core\Http\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 class CheckBeUserAuthorization implements MiddlewareInterface

--- a/Classes/Middleware/CheckBeUserAuthorization.php
+++ b/Classes/Middleware/CheckBeUserAuthorization.php
@@ -22,14 +22,14 @@ class CheckBeUserAuthorization implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $tsfe = $this->getTyposcriptFrontendController();
+        $tsfe = $this->getTypoScriptFrontendController();
         if (!$tsfe->isBackendUserLoggedIn()) {
             return new Response('php://temp', '401');
         }
         return $handler->handle($request);
     }
 
-    protected function getTyposcriptFrontendController(): TypoScriptFrontendController
+    protected function getTypoScriptFrontendController(): TypoScriptFrontendController
     {
         return $GLOBALS['TSFE'];
     }

--- a/Classes/Middleware/TypoScriptFrontendInitialization.php
+++ b/Classes/Middleware/TypoScriptFrontendInitialization.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Aspect\PreviewAspect;
@@ -32,12 +33,12 @@ class TypoScriptFrontendInitialization implements MiddlewareInterface
         return $handler->handle($request);
     }
 
-    protected function getTyposcriptFrontendController($request): ?TypoScriptFrontendController
+    protected function getTypoScriptFrontendController($request): ?TypoScriptFrontendController
     {
         $GLOBALS['TYPO3_REQUEST'] = $request;
         /** @var Site $site */
         $site = $request->getAttribute('site', null);
-        $pageArguments = $request->getAttribute('routing', null);
+        $pageArguments = new PageArguments(0, '0', []);
         $this->context->setAspect('frontend.preview', GeneralUtility::makeInstance(PreviewAspect::class));
 
         /** @var TypoScriptFrontendController $controller */

--- a/Classes/Schema/PagesJsonApiSchema.php
+++ b/Classes/Schema/PagesJsonApiSchema.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace DFAU\ToujouApi\Schema;
 
-use DFAU\Convergence\Schema\InterGraphResourceRelation;
-use DFAU\Convergence\Schema\ExpressionIdentifier;
-use DFAU\Convergence\Schema\IntraGraphResourceRelation;
-use DFAU\Convergence\Schema\ExpressionQualifier;
-use DFAU\Convergence\Schema\StringPropertyPathReferenceList;
-use DFAU\Convergence\Schema\ResourcePropertiesExtractor;
-use DFAU\Convergence\Schema\PropertyPathPropertyList;
 use DFAU\Convergence\Schema;
+use DFAU\Convergence\Schema\ExpressionIdentifier;
+use DFAU\Convergence\Schema\ExpressionQualifier;
+use DFAU\Convergence\Schema\InterGraphResourceRelation;
+use DFAU\Convergence\Schema\IntraGraphResourceRelation;
+use DFAU\Convergence\Schema\PropertyPathPropertyList;
+use DFAU\Convergence\Schema\ResourcePropertiesExtractor;
+use DFAU\Convergence\Schema\StringPropertyPathReferenceList;
 
 class PagesJsonApiSchema extends Schema
 {

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,15 +1,14 @@
 <?php
 
 declare(strict_types=1);
-use DFAU\ToujouOauth2Server\Middleware\ResourceServerMiddleware;
-use DFAU\ToujouApi\Middleware\CheckBeUserAuthorization;
-
 use DFAU\ToujouApi\Middleware\ApiEntrypoint;
+use DFAU\ToujouApi\Middleware\CheckBeUserAuthorization;
 use DFAU\ToujouApi\Middleware\JsonApiPayload;
 use DFAU\ToujouApi\Middleware\LanguageResolver;
 use DFAU\ToujouApi\Middleware\ParsedBodyReset;
 use DFAU\ToujouApi\Middleware\Router;
 use DFAU\ToujouApi\Middleware\TypoScriptFrontendInitialization;
+use DFAU\ToujouOauth2Server\Middleware\ResourceServerMiddleware;
 
 return [
     'frontend' => [

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -23,15 +23,14 @@ return [
         'dfau/toujou-api/resource-server' => [
             'target' => ResourceServerMiddleware::class,
         ],
-        'dfau/toujou-api/language-resolve' => [
-            'target' => LanguageResolver::class,
-            'after' => ['dfau/toujou-api/resource-server'],
-        ],
         'dfau/toujou-api/tsfe' => [
             'target' => TypoScriptFrontendInitialization::class,
-            'after' => ['dfau/toujou-api/language-resolve'],
+            'after' => ['dfau/toujou-api/resource-server'],
         ],
-
+        'dfau/toujou-api/language-resolve' => [
+            'target' => LanguageResolver::class,
+            'after' => ['dfau/toujou-api/tsfe'],
+        ],
         'dfau/toujou-api/check-be-user-authorization' => [
             'target' => CheckBeUserAuthorization::class,
             'after' => ['dfau/toujou-api/tsfe'],

--- a/Configuration/ToujouApi/CommandBus.php
+++ b/Configuration/ToujouApi/CommandBus.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 use DFAU\ToujouApi\CommandBus\CommandHandlerContainer;
 use DFAU\ToujouApi\CommandBus\MapByConfiguration;
-
 use DFAU\ToujouApi\Domain\Command\CreateTcaResourceCommand;
 use DFAU\ToujouApi\Domain\Command\DeleteTcaResourceCommand;
 use DFAU\ToujouApi\Domain\Command\ReplaceTcaResourceCommand;

--- a/Configuration/ToujouApi/Resources.php
+++ b/Configuration/ToujouApi/Resources.php
@@ -1,28 +1,22 @@
 <?php
 
 declare(strict_types=1);
-use DFAU\ToujouApi\Domain\Repository\TcaResourceRepository;
-use DFAU\ToujouApi\TransformHandler\MetaTransformHandler;
-use DFAU\ToujouApi\TransformHandler\TcaResourceTransformHandler;
-use DFAU\ToujouApi\IncludeHandler\PageRelationIncludeHandler;
 use DFAU\ToujouApi\Domain\Command\CreateTcaResourceCommand;
-use DFAU\ToujouApi\Domain\Command\UpdateTcaResourceCommand;
 use DFAU\ToujouApi\Domain\Command\DeleteTcaResourceCommand;
 use DFAU\ToujouApi\Domain\Command\ReplaceTcaResourceCommand;
-use DFAU\ToujouApi\Schema\PagesJsonApiSchema;
-use DFAU\ToujouApi\IncludeHandler\TcaResourceIncludeHandler;
+use DFAU\ToujouApi\Domain\Command\UpdateTcaResourceCommand;
 use DFAU\ToujouApi\Domain\Repository\FileReferenceRepository;
-use DFAU\ToujouApi\Domain\Transformer\FileReferenceTransformer;
 use DFAU\ToujouApi\Domain\Repository\FileRepository;
+use DFAU\ToujouApi\Domain\Repository\TcaResourceRepository;
+use DFAU\ToujouApi\Domain\Transformer\FileReferenceTransformer;
 use DFAU\ToujouApi\Domain\Transformer\FileTransformer;
-
-use DFAU\ToujouApi\Domain\Command;
-use DFAU\ToujouApi\Domain\Repository;
-use DFAU\ToujouApi\Domain\Transformer;
-use DFAU\ToujouApi\IncludeHandler;
+use DFAU\ToujouApi\IncludeHandler\PageRelationIncludeHandler;
+use DFAU\ToujouApi\IncludeHandler\TcaResourceIncludeHandler;
 use DFAU\ToujouApi\Resource\Operation;
+use DFAU\ToujouApi\Schema\PagesJsonApiSchema;
 use DFAU\ToujouApi\Transformer as GenericTransformer;
-use DFAU\ToujouApi\TransformHandler;
+use DFAU\ToujouApi\TransformHandler\MetaTransformHandler;
+use DFAU\ToujouApi\TransformHandler\TcaResourceTransformHandler;
 
 return [
     'pages' => [

--- a/Tests/Acceptance/Support/Helper/ApiAccess.php
+++ b/Tests/Acceptance/Support/Helper/ApiAccess.php
@@ -6,6 +6,7 @@ namespace DFAU\ToujouApi\Tests\Acceptance\Support\Helper;
 
 use Codeception\Module;
 use Codeception\Module\REST;
+
 class ApiAccess extends Module
 {
     protected $requiredFields = ['grant_type', 'client_id', 'client_secret'];

--- a/Tests/Unit/Database/Query/Restriction/LanguageRestrictionTest.php
+++ b/Tests/Unit/Database/Query/Restriction/LanguageRestrictionTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DFAU\ToujouApi\Tests\Unit\Database\Query\Restriction;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use DFAU\ToujouApi\Database\Query\Restriction\LanguageRestriction;
+use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;

--- a/Tests/Unit/Middleware/LanguageResolverTest.php
+++ b/Tests/Unit/Middleware/LanguageResolverTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DFAU\ToujouApi\Tests\Unit\Middleware;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use DFAU\ToujouApi\Middleware\LanguageResolver;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;

--- a/Tests/Unit/Middleware/TypoScriptFrontendInitializationTest.php
+++ b/Tests/Unit/Middleware/TypoScriptFrontendInitializationTest.php
@@ -52,7 +52,7 @@ class TypoScriptFrontendInitializationTest extends UnitTestCase
 
         $requestMock
             ->method('getAttribute')
-            ->withConsecutive(['site'], ['routing'], ['language'])
+            ->withConsecutive(['site'], ['language'])
             ->willReturnOnConsecutiveCalls($siteMock, $pageArgumentsMock, $siteLanguageMock);
 
         $this->subject->process($requestMock, $requestHandlerMock);

--- a/composer.json
+++ b/composer.json
@@ -57,10 +57,5 @@
             "web-dir": ".Build/Web",
             "extension-key": "toujou_api"
         }
-    },
-    "scripts": {
-        "post-autoload-dump": [
-            "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
-        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "dfau/convergence": "dev-master",
         "typo3/cms-core": "^11.5",
         "league/fractal": "~0.18",
-        "league/tactician": "^2.0-rc1",
+        "league/tactician": "dev-master",
         "nikic/fast-route": "^1.3.0",
         "nikolaposa/cascader": "^1.2.0",
         "middlewares/error-handler": "^3.0.0",

--- a/etc/testing-docker/docker-compose.yml
+++ b/etc/testing-docker/docker-compose.yml
@@ -358,6 +358,7 @@ services:
           set -x
         fi
         php -v | grep '^PHP';
+        ln -sfn ${ROOT_DIR} Web/typo3conf/ext/toujou_api
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
           bin/phpunit -c vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};

--- a/etc/testing-docker/docker-compose.yml
+++ b/etc/testing-docker/docker-compose.yml
@@ -69,6 +69,7 @@ services:
         done;
         echo Database is up;
         php -v | grep '^PHP';
+        ln -sfn ${ROOT_DIR} Web/typo3conf/ext/toujou_api
         mkdir -p Web/typo3temp/var/tests/
         COMMAND=\"vendor/codeception/codeception/codecept run Api -d -c Web/typo3conf/ext/toujou_api/Tests/codeception.yml ${TEST_FILE}\"
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then

--- a/etc/testing-docker/docker-compose.yml
+++ b/etc/testing-docker/docker-compose.yml
@@ -76,10 +76,9 @@ services:
           XDEBUG_MODE=\"off\" \
           $${COMMAND};
         else
-          DOCKER_HOST=`route -n | awk '/^0.0.0.0/ { print $$2 }'`
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
-          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=$${DOCKER_HOST}\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
           $${COMMAND};
         fi
       "


### PR DESCRIPTION
2 Acceptance Tests are still failing as well.
1. `LanguageHandlingCest: Test alternative language via accept language header`
2. `LanguageHandlingCest: Test alternative language for translated records`